### PR TITLE
fixed typo from 'Training has starting' to '...has started'

### DIFF
--- a/cacli/cmd/progress/progress.go
+++ b/cacli/cmd/progress/progress.go
@@ -208,7 +208,7 @@ func Run(_ *cobra.Command, args []string) {
 		}
 
 		// otherwise show preparing to train message.
-		s.Suffix = " Training has starting, waiting for a progress update..."
+		s.Suffix = " Training has started, waiting for a progress update..."
 		s.Start()
 		return
 	})


### PR DESCRIPTION
I noticed this when checking the progress of my training run. Cheers!